### PR TITLE
docs(README.md): Fix the "example files" hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Files ending with `.mustache` have values to fill in to use (and the
 This can (and should) be done automatically using a mustache command-line (many
 `mustache` implementations are available from the [Mustache website](https://mustache.github.io).
 To do so, you must write a `meta.yml` file containing the requested values.
-For instance, the [example files](https://github.com/coq-community/manifesto) were generated in the
+For instance, the [example files](https://github.com/coq-community/manifesto/tree/master/templates/examples) were generated in the
 following way:
 
 ``` shell


### PR DESCRIPTION
[Just a minor suggestion]

Also, a question:
should I replace the URL https://github.com/coq-community/manifesto/tree/master/templates with https://github.com/coq-community/templates for the two "templates" hyperlinks in the docker-coq wiki?

* https://github.com/coq-community/docker-coq/wiki/CI-setup#travis-ci-config
* https://github.com/coq-community/docker-coq/wiki/CI-setup#related-links

(BTW I've seen there is https://github.com/coq-community/manifesto/pull/69, but I don't know what is the status of this PR…)