### PR TITLE
CircleCI badge in README template

### DIFF
--- a/README.md.mustache
+++ b/README.md.mustache
@@ -1,6 +1,11 @@
 # {{& fullname }}
 
+{{# travis }}
 [![Travis][travis-shield]][travis-link]
+{{/ travis }}
+{{# circleci }}
+[![CircleCI][circleci-shield]][circleci-link]
+{{/ circleci }}
 {{# community }}
 [![Contributing][contributing-shield]][contributing-link]
 [![Code of Conduct][conduct-shield]][conduct-link]
@@ -10,8 +15,14 @@
 [![DOI][doi-shield]][doi-link]
 {{/ paper }}
 
+{{# travis }}
 [travis-shield]: https://travis-ci.com/{{ organization }}/{{ shortname }}.svg?branch=master
 [travis-link]: https://travis-ci.com/{{ organization }}/{{ shortname }}/builds
+{{/ travis }}
+{{# circleci }}
+[circleci-shield]: https://circleci.com/gh/{{ organization }}/{{ shortname }}.svg?style=svg
+[circleci-link]:   https://circleci.com/gh/{{ organization }}/{{ shortname }}
+{{/ circleci }}
 
 {{# community }}
 [contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg


### PR DESCRIPTION
Related issue: #1 

## Motivation
CircleCI is getting popular in Coq projects in and outside the community:
- [Cérès](https://github.com/Lysxia/coq-ceres/blob/master/.circleci/config.yml)
- [Ext-Lib](https://github.com/coq-community/coq-ext-lib/blob/master/.circleci/config.yml)
- [QuickChick](https://github.com/QuickChick/QuickChick/blob/8.10/.circleci/config.yml)
- [Reduction Effects](https://github.com/coq-community/reduction-effects/blob/master/.circleci/config.yml)
- [Simple IO](https://github.com/Lysxia/coq-simple-io/blob/master/.circleci/config.yml)
- [Software Foundations Chinese Translation](https://github.com/Coq-zh/SF-zh/blob/master/.circleci/config.yml)
    + The English version (in private repo) also uses CircleCI.



## Todo
- [ ] CircleCI configuration template
  As suggested in https://github.com/coq-community/templates/issues/1#issuecomment-541939713, we could propose a template to CircleCI directly, since the purpose of CircleCI is to allow developers customize testing scripts conveniently.