### PR TITLE
Override opam package name

### DIFF
--- a/.travis.yml.mustache
+++ b/.travis.yml.mustache
@@ -49,7 +49,7 @@ matrix:
 {{# tested_coq_opam_versions }}
   - env:
     - COQ_IMAGE=coqorg/coq:{{ version }}
-    - PACKAGE=coq-{{ shortname }}.{{ opam-file-version }}{{^ opam-file-version }}dev{{/ opam-file-version }}
+    - PACKAGE={{# opam-name}}{{ opam-name }}{{/ opam-name}}{{^ opam-name}}coq-{{ shortname }}{{/ opam-name}}.{{ opam-file-version }}{{^ opam-file-version }}dev{{/ opam-file-version }}
     - NJOBS=2
     <<: *OPAM
 {{/ tested_coq_opam_versions }}

--- a/README.md.mustache
+++ b/README.md.mustache
@@ -84,7 +84,7 @@ is via [OPAM](https://opam.ocaml.org/doc/Install.html):
 
 ```shell
 opam repo add coq-released https://coq.inria.fr/opam/released
-opam install coq-{{ shortname }}
+opam install {{# opam-name}}{{ opam-name }}{{/ opam-name}}{{^ opam-name}}coq-{{ shortname }}{{/ opam-name}}
 ```
 
 To instead build and install manually, do:


### PR DESCRIPTION
Motivation: if `shortname` (which could maybe named `repo-name`) is something like `coq-blah`
then it does not make much sense to name opam package `coq-coq-blah`.