### PR TITLE
avoid referring to template-examples in manifesto repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,41 +13,41 @@
 [gitter-shield]: https://img.shields.io/badge/chat-on%20gitter-%23c1272d.svg
 [gitter-link]: https://gitter.im/coq-community/Lobby
 
-This repository contains a few reusable files for Coq-community (or external)
-Coq projects.
+This repository contains template files for use in generating configuration files
+and other boilerplate for coq-community (or external) Coq projects.
 
-Files ending with `.mustache` have values to fill in to use (and the
-`.mustache` extension should be removed).
+Files ending in `.mustache` have values to fill in (and the `.mustache`
+extension should be removed from the resulting files). Filling in values can (and should)
+be done automatically using a mustache command-line tool. There are many mustache
+implementations available at the [Mustache website](https://mustache.github.io).
 
-This can (and should) be done automatically using a mustache command-line (many
-`mustache` implementations are available from the [Mustache website](https://mustache.github.io).
-To do so, you must write a `meta.yml` file containing the requested values.
-For instance, the [example files](https://github.com/coq-community/manifesto/tree/master/template-examples) were generated in the
-following way:
-
-``` shell
-for dir in examples/*; do
-  for f in default.nix.mustache README.md.mustache .travis.yml.mustache; do
-    mustache $dir/meta.yml $f > $dir/${f%.mustache} && \
-    echo "$dir/${f%.mustache}"
-  done
-  mustache $dir/meta.yml coq.opam.mustache > $dir/coq-${dir#examples/}.opam && \
-  echo "$dir/coq-${dir#examples/}.opam"
-done
+To enable generating files using a mustache tool, you should write a `meta.yml`
+file containing the required values. For example, assuming the templates
+are available in a sibling directory, configuration and boilerplate
+files in the [AAC Tactics](https://github.com/coq-community/aac-tactics.git)
+project are generated as follows:
+```shell
+mustache meta.yml ../templates/default.nix.mustache > default.nix && \
+mustache meta.yml ../templates/README.md.mustache > README.md && \
+mustache meta.yml ../templates/.travis.yml.mustache > .travis.yml && \
+mustache meta.yml ../templates/coq.opam.mustache > coq-aac-tactics.opam
 ```
+Other projects using the templates in a similar way include
+[Chapar](https://github.com/coq-community/chapar) and
+[Lemma Overloading](https://github.com/coq-community/lemma-overloading).
 
-You can generate the standard files from the templates,
-provided you already have written `meta.yml`, like this:
+You can generate the standard files from the templates, provided
+you have already written `meta.yml`, in the following way:
 ```shell
 cd <your_coq_project> && cd ..
-git clone git@github.com:coq-community/templates.git
+git clone https://github.com/coq-community/templates.git
 cd -
 ../templates/generate.sh
 git add <the_generated_files>
 ```
-Yes, keeping generated files in VCS isn't ideal, but `README.md` has to be there,
-and generally this is a common practice with using Autotools, for example.
-To get the `mustache` utility, in e.g. NixOS you could `nix-env -i mustache-go`.
+Keeping generated files under version control is not ideal, but `README.md` has to exist,
+and generally this is a common practice when using build systems such as Autotools.
+To get a `mustache` tool in, e.g., NixOS, you can run `nix-env -i mustache-go`.
 
-You may find documentation, advice and guidelines on how to maintain a project
+You can find documentation, advice, and guidelines on how to maintain a Coq project
 in the [wiki](https://github.com/coq-community/manifesto/wiki).


### PR DESCRIPTION
As requested by @Zimmi48 in https://github.com/coq-community/manifesto/pull/95