### PR TITLE
Fix generate.sh

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 for f in `dirname $0`/{,.}*.mustache
 do


### PR DESCRIPTION
POSIX shells do not support brace expansion, so `{,.}` requires bash or so.