### PR TITLE
Add missing (implied) .git suffix in the "git clone" command

### DIFF
--- a/README.md.mustache
+++ b/README.md.mustache
@@ -90,7 +90,7 @@ opam install coq-{{ shortname }}
 To instead build and install manually, do:
 
 ``` shell
-git clone https://github.com/{{ organization }}/{{ shortname }}
+git clone https://github.com/{{ organization }}/{{ shortname }}.git
 cd {{ shortname }}
 make   # or make -j <number-of-cores-on-your-machine>
 make install


### PR DESCRIPTION
(a detail in the README.md template)