### PR TITLE
Fix Travis CI "Build config validation" errors

### DIFF
--- a/.travis.yml.mustache
+++ b/.travis.yml.mustache
@@ -1,6 +1,9 @@
-opam: &OPAM
-  language: minimal
-  sudo: required
+os: linux
+dist: bionic
+language: shell
+
+.opam: &OPAM
+  language: shell
   services: docker
   install: |
     # Prepare the COQ container
@@ -30,12 +33,12 @@ opam: &OPAM
   - docker stop COQ  # optional
   - echo -en 'travis_fold:end:script\\r'
 
-nix: &NIX
+.nix: &NIX
   language: nix
   script:
   - nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
 
-matrix:
+jobs:
   include:
 
   # Test supported versions of Coq via Nix


### PR DESCRIPTION
This PR improves the `.travis.yml` for several minor or not-so-minor issues, now spotted automatically by Travis CI's `Build config validation`

## Beforehand - <a href="https://travis-ci.com/github/coq-community/coqoban/builds/152692345/config">source</a>

![2020-03-10_19-44-42_Screenshot_Travis_Build_config_validation](https://user-images.githubusercontent.com/10367254/76349193-d5bcd800-6309-11ea-8600-d5625fa75a8b.png)

## Henceforth - <a href="https://travis-ci.com/github/coq-community/coqoban/jobs/296651863/config">source</a>

![2020-03-10_20-04-20_Screenshot_Travis_Build_config_validation_OK](https://user-images.githubusercontent.com/10367254/76349504-6eebee80-630a-11ea-9b98-9afbe7952cef.png)

