### PR TITLE
Rename description field of dependencies and add a default value.

### DIFF
--- a/README.md.mustache
+++ b/README.md.mustache
@@ -79,7 +79,7 @@
 - Compatible OCaml versions: {{& text }}
 {{/ supported_ocaml_versions }}
 - Additional dependencies:{{# dependencies }}
-  - {{& description }}{{/ dependencies }}{{^ dependencies }} none{{/ dependencies }}
+  - {{& text_description }}{{^ text_description }}{{# opam }}{{ name }}{{/ opam }}{{/ text_description}}{{/ dependencies }}{{^ dependencies }} none{{/ dependencies }}
 - Coq namespace: `{{ namespace }}`
 - Related publication(s):{{# publications }}
   - [{{& pub_title }}]({{ pub_url }}) {{# pub_doi }}doi:[{{ pub_doi }}](https://doi.org/{{ pub_doi }}){{/ pub_doi}}{{/ publications }}{{^ publications }} none{{/ publications }}


### PR DESCRIPTION
If the description field of a dependency is not provided, the description of the project itself was used instead.  We avoid this by renaming the former field, and we default to using the opam name when
the description is not provided.

This avoids an issue reported by @gmalecha on Gitter (https://gitter.im/coq-community/Lobby?at=5eb0827b14b48f0698ac6a3d).