### PR TITLE
feat: Add ci_extra_dev

### DIFF
--- a/.travis.yml.mustache
+++ b/.travis.yml.mustache
@@ -14,7 +14,9 @@ language: shell
       echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
       export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
       set -ex  # -e = exit on failure; -x = trace for debug
+{{# ci_extra_dev }}
       opam repo -a --set-default add coq-extra-dev https://coq.inria.fr/opam/extra-dev
+{{/ ci_extra_dev }}
       opam update -y
       opam pin add ${PACKAGE} . -y -n -k path
       opam install ${PACKAGE} -y -j ${NJOBS} --deps-only

--- a/config.yml.mustache
+++ b/config.yml.mustache
@@ -24,7 +24,9 @@ jobs:
     - run:
         name: Install dependencies
         command: |
+{{# ci_extra_dev }}
           opam repo -a --set-default add coq-extra-dev https://coq.inria.fr/opam/extra-dev
+{{/ ci_extra_dev }}
           opam update
           opam install --deps-only .
     - run:

--- a/ref.yml
+++ b/ref.yml
@@ -52,6 +52,11 @@ fields:
       used:
         - config.yml
         - .travis.yml
+  - ci_extra_dev:
+      type: bool
+      used:
+        - config.yml
+        - .travis.yml
   - community:
       type: bool
       description: >


### PR DESCRIPTION
Motivation: https://github.com/coq-community/reglang/pull/13#discussion_r432364516

After this change, by default extra-dev is only included when building on Coq dev.