### PR TITLE
allow specifying the Docker repo for 'tested_coq_opam_versions' for use in .travis.yml

### DIFF
--- a/.travis.yml.mustache
+++ b/.travis.yml.mustache
@@ -62,7 +62,7 @@ jobs:
   # Test supported versions of Coq via OPAM
 {{# tested_coq_opam_versions }}
   - env:
-    - COQ_IMAGE=coqorg/coq:{{ version }}
+    - COQ_IMAGE={{ repo }}{{^ repo }}coqorg/coq{{/ repo }}:{{ version }}
     - PACKAGE={{ opam_name }}{{^ opam_name }}coq-{{ shortname }}{{/ opam_name }}.{{ opam-file-version }}{{^ opam-file-version }}dev{{/ opam-file-version }}
     - NJOBS=2
     <<: *OPAM

--- a/ref.yml
+++ b/ref.yml
@@ -373,6 +373,16 @@ fields:
             examples:
               - '8.11'
               - 'dev'
+        - repo:
+            required: false
+            description: >
+              Docker repository supporting the given docker tag.
+              Defaults to 'coqorg/coq'.
+            examples:
+              - 'mathcomp/mathcomp'
+              - 'mathcomp/mathcomp-dev'
+            used:
+              - .travis.yml
       used:
         - .travis.yml
         - coq-action.yml


### PR DESCRIPTION
This PR implements the enhancement proposed in #39 