### PR TITLE
allow specifying the Docker repo for 'tested_coq_opam_versions' for use in coq-action.yml

### DIFF
--- a/coq-action.yml.mustache
+++ b/coq-action.yml.mustache
@@ -20,17 +20,17 @@ jobs:
 {{/ tested_coq_opam_versions }}
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 {{# submodule }}
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@2.1.1
+      - name: Checkout submodules
+        uses: textbook/git-checkout-submodule-action@2.1.1
 {{/ submodule }}
-    - uses: coq-community/docker-coq-action@v1
-      with:
-        opam_file: '{{ opam_name }}{{^ opam_name }}coq-{{ shortname }}{{/ opam_name }}.opam'
+      - uses: coq-community/docker-coq-action@v1
+        with:
+          opam_file: '{{ opam_name }}{{^ opam_name }}coq-{{ shortname }}{{/ opam_name }}.opam'
 {{! Change delimiters to avoid the next line being parsed as mustache syntax. }}
 {{=<% %>=}}
-        custom_image: ${{ matrix.image }}
+          custom_image: ${{ matrix.image }}
 
 # See also:
 # https://github.com/coq-community/docker-coq-action#readme

--- a/coq-action.yml.mustache
+++ b/coq-action.yml.mustache
@@ -14,11 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        coq_version:
+        image:
 {{# tested_coq_opam_versions }}
-          - '{{ version }}'
+          - '{{ repo }}{{^ repo }}coqorg/coq{{/ repo }}:{{ version }}'
 {{/ tested_coq_opam_versions }}
-        ocaml_version: ['minimal']
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
@@ -29,10 +28,9 @@ jobs:
     - uses: coq-community/docker-coq-action@v1
       with:
         opam_file: '{{ opam_name }}{{^ opam_name }}coq-{{ shortname }}{{/ opam_name }}.opam'
-{{! Change delimiters to avoid the next two lines being parsed as mustache syntax. }}
+{{! Change delimiters to avoid the next line being parsed as mustache syntax. }}
 {{=<% %>=}}
-        coq_version: ${{ matrix.coq_version }}
-        ocaml_version: ${{ matrix.ocaml_version }}
+        custom_image: ${{ matrix.image }}
 
 # See also:
 # https://github.com/coq-community/docker-coq-action#readme

--- a/ref.yml
+++ b/ref.yml
@@ -383,6 +383,7 @@ fields:
               - 'mathcomp/mathcomp-dev'
             used:
               - .travis.yml
+              - coq-action.yml
       used:
         - .travis.yml
         - coq-action.yml


### PR DESCRIPTION
Follow-up of https://github.com/coq-community/templates/pull/57