### PR TITLE
feat: Enable GitHub Action builds for any PR

### DIFF
--- a/coq-action.yml.mustache
+++ b/coq-action.yml.mustache
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
     branches:
-      - master
+      - '**'
 
 jobs:
   build:


### PR DESCRIPTION
* The coq-action now behaves closer like Travis CI and its pr builds.

* The configuration still prevents the "double-build" concern when one opens a PR from an upstream-repo branch.