### PR TITLE
dune support in README.md and coq.opam

### DIFF
--- a/README.md.mustache
+++ b/README.md.mustache
@@ -79,7 +79,8 @@
 - Compatible OCaml versions: {{& text }}
 {{/ supported_ocaml_versions }}
 - Additional dependencies:{{# dependencies }}
-  - {{& description }}{{/ dependencies }}{{^ dependencies }} none{{/ dependencies }}
+  - {{& description }}{{/ dependencies }}{{^ dependencies }}{{^ dune }} none{{/ dune }}{{/ dependencies }}{{# dune }}
+  - [Dune](https://dune.build) 2.5 or later{{/ dune }}
 - Coq namespace: `{{ namespace }}`
 - Related publication(s):{{# publications }}
   - [{{& pub_title }}]({{ pub_url }}) {{# pub_doi }}doi:[{{ pub_doi }}](https://doi.org/{{ pub_doi }}){{/ pub_doi}}{{/ publications }}{{^ publications }} none{{/ publications }}
@@ -99,8 +100,14 @@ To instead build and install manually, do:
 ``` shell
 git clone {{# submodule }}--recurse-submodules {{/ submodule }}https://github.com/{{ organization }}/{{ shortname }}.git
 cd {{ shortname }}
+{{# dune }}
+dune build
+dune install
+{{/ dune}}
+{{^ dune }}
 make {{ make_target }}  # or make -j <number-of-cores-on-your-machine> {{ make_target }}
 make install
+{{/ dune }}
 ```
 {{/ build }}
 

--- a/coq.opam.mustache
+++ b/coq.opam.mustache
@@ -12,12 +12,20 @@ synopsis: "{{& synopsis }}"
 description: """
 {{& description }}"""
 
+{{# dune }}
+build: ["dune" "build" "-p" name "-j" jobs]
+{{/ dune }}
+{{^ dune }}
 build: [make "-j%{jobs}%" {{ make_target }}]
 install: [make "install"]
+{{/ dune }}
 depends: [
 {{# supported_ocaml_versions }}
   "ocaml" {{& opam }}
 {{/ supported_ocaml_versions }}
+{{# dune }}
+  "dune" {>= "2.5"}
+{{/ dune }}
   "coq" {{& supported_coq_versions.opam }}
 {{# dependencies }}
 {{# opam }}

--- a/dune-project.mustache
+++ b/dune-project.mustache
@@ -1,0 +1,3 @@
+(lang dune 2.5)
+(using coq 0.2)
+(name {{ shortname }})

--- a/dune.mustache
+++ b/dune.mustache
@@ -1,0 +1,4 @@
+(coq.theory
+ (name {{ namespace }})
+ (package {{ opam_name }}{{^ opam_name }}coq-{{ shortname }}{{/ opam_name }})
+ (synopsis "{{& synopsis }}"))

--- a/ref.yml
+++ b/ref.yml
@@ -11,7 +11,7 @@ fields:
       required: true
       description: >
         The name of the repository.  Will also be used to build the
-        name of the opam file, unless opam_file is provided.
+        name of the opam file, unless opam_name is provided.
       used:
         - README.md
         - index.md
@@ -19,6 +19,8 @@ fields:
         - extracted.opam
         - config.yml
         - default.nix
+        - dune
+        - dune-project
   - opam_name:
       required: false
       default: coq-{{ shortname }}
@@ -26,6 +28,8 @@ fields:
         - README.md
         - .travis.yml
         - coq-action.yml
+        - dune-project
+        - dune
   - organization:
       required: true
       used:
@@ -75,6 +79,11 @@ fields:
         - README.md
         - config.yml
         - coq-action.yml
+  - dune:
+      type: bool
+      used:
+        - README.md
+        - coq.opam
   - doi:
       required: false
       used:
@@ -83,6 +92,7 @@ fields:
       required: true
       used:
         - coq.opam
+        - dune
   - description:
       required: true
       used:
@@ -231,6 +241,7 @@ fields:
       used:
         - README.md
         - coq.opam
+        - dune
   - publications:
       type: list
       item_fields:


### PR DESCRIPTION
Dune is activated by a simple `dune: true` as per #38. I have no idea how to add dune support for Nix builds, but on the other hand I use regular make builds in Nix for all my personal projects (to find errors in both dune and make builds).

Fixes #38.