### PR TITLE
Support adding more info after authors (e.g. a list of contributors).

### DIFF
--- a/README.md.mustache
+++ b/README.md.mustache
@@ -62,7 +62,7 @@
 - Author(s):
 {{# authors }}
   - {{& name }}{{# initial }} (initial){{/ initial }}
-{{/ authors }}
+{{/ authors }}{{& after_authors }}
 {{# community }}
 - Coq-community maintainer(s):
 {{# maintainers }}

--- a/index.md.mustache
+++ b/index.md.mustache
@@ -53,4 +53,4 @@ Other related publications, if any, are listed below.
 
 {{# authors }}
 - {{& name }}
-{{/ authors }}
+{{/ authors }}{{& after_authors }}

--- a/ref.yml
+++ b/ref.yml
@@ -123,6 +123,11 @@ fields:
             used:
               - coq.opam
               - extracted.opam
+  - after_authors:
+      required: false
+      used:
+        - README.md
+        - index.md
   - maintainers:
       type: list
       item_fields:


### PR DESCRIPTION
This PR adds a list of names of contributors. This is to give credit to people who contributed to a library without making them authors outright. Currently, this is displayed as two separate lists in `README.md` and as a joint list (as per the existing "Authors and Contributors" heading) in `index.md`.