### PR TITLE
turn coqdoc_index into relative URL

### DIFF
--- a/README.md.mustache
+++ b/README.md.mustache
@@ -47,7 +47,7 @@
 
 {{# coqdoc }}
 [coqdoc-shield]: https://img.shields.io/badge/docs-coqdoc-blue.svg
-[coqdoc-link]: https://{{# community }}coq-community.org{{/ community }}{{^ community }}{{ organization }}.github.io{{/ community }}/{{ shortname }}
+[coqdoc-link]: https://{{# community }}coq-community.org{{/ community }}{{^ community }}{{ organization }}.github.io{{/ community }}/{{ shortname }}{{# coqdoc_index }}/{{ coqdoc_index }}{{/coqdoc_index}}
 {{/ coqdoc }}
 
 {{# doi }}

--- a/index.md.mustache
+++ b/index.md.mustache
@@ -30,12 +30,11 @@ The current stable release of {{& fullname }} can be [downloaded from GitHub](ht
 
 ## Documentation
 
-{{ coqdoc_index }}
-{{^ coqdoc_index }}
-The coqdoc presentations of the source files from releases can be browsed online.
+{{# coqdoc_index }}
+The coqdoc presentation of the source files can be browsed [here]({{ coqdoc_index }})
 {{/ coqdoc_index }}
 
-Other related publications, if any, are listed below.
+Related publications, if any, are listed below.
 
 {{# publications }}
 - [{{& pub_title }}]({{ pub_url }}) {{# pub_doi }}doi:[{{ pub_doi }}](https://doi.org/{{ pub_doi }}){{/ pub_doi}}

--- a/ref.yml
+++ b/ref.yml
@@ -342,9 +342,13 @@ fields:
       used:
         - README.md
   - coqdoc_index:
-      description: Link to Coqdoc pages in index.
+      required: false
+      description: Position of to Coqdoc pages relative to index
       used:
         - index.md
+        - README.md
+      examples:
+        - "docs/latest/coqdoc/toc.html"
   - opam-file-maintainer:
       required: false
       default: palmskog@gmail.com

--- a/ref.yml
+++ b/ref.yml
@@ -343,7 +343,7 @@ fields:
         - README.md
   - coqdoc_index:
       required: false
-      description: Position of to Coqdoc pages relative to index
+      description: Position of Coqdoc main page relative to index
       used:
         - index.md
         - README.md


### PR DESCRIPTION
This PR turns the `coqdoc_index` variable into a URL relative to the (usual) position of the `index.html` file. The main rationale is that this allows the `coqdoc` badge to actually point to the documentation rather than the project description page while generating a reasonable `index.md` that points to the same place. 

It also removes the alternative sentence "The coqdoc presentations of the source files from releases can be browsed online.", because this sentence makes no sense unless one manually edits `index.md` (or `index.html`), in which case one can easily also add a description of the added content.