### PR TITLE
Allow to define a reference branch other than `master'

### DIFF
--- a/README.md.mustache
+++ b/README.md.mustache
@@ -22,11 +22,11 @@
 {{/ doi }}
 
 {{# travis }}
-[travis-shield]: https://travis-ci.com/{{ organization }}/{{ shortname }}.svg?branch=master
+[travis-shield]: https://travis-ci.com/{{ organization }}/{{ shortname }}.svg?branch={{branch}}{{^branch}}master{{/branch}}
 [travis-link]: https://travis-ci.com/{{ organization }}/{{ shortname }}/builds
 {{/ travis }}
 {{# action }}
-[action-shield]: https://github.com/{{ organization }}/{{ shortname }}/workflows/CI/badge.svg?branch=master
+[action-shield]: https://github.com/{{ organization }}/{{ shortname }}/workflows/CI/badge.svg?branch={{branch}}{{^branch}}master{{/branch}}
 [action-link]: https://github.com/{{ organization }}/{{ shortname }}/actions?query=workflow%3ACI
 {{/ action }}
 {{# circleci }}

--- a/ref.yml
+++ b/ref.yml
@@ -21,6 +21,14 @@ fields:
         - default.nix
         - dune
         - dune-project
+  - branch:
+      required: false
+      description: >
+        The name of the branch of reference to consider to get the latest
+        version of the software. It will also be used for the CI badges.
+        If omitted, default value is “master”.
+        use:
+          - README.md
   - opam_name:
       required: false
       default: coq-{{ shortname }}


### PR DESCRIPTION
Fixes coq-community/templates#55