### PR TITLE
Fix header link in index.md

### DIFF
--- a/index.md.mustache
+++ b/index.md.mustache
@@ -11,7 +11,7 @@ header-includes:
 ---
 
 <div style="text-align:left"><img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" height="25" style="border:0px">
-[View the project on GitHub](https://github.com/{{ organization }}/{{ shortname }})
+<a href="https://github.com/{{ organization }}/{{ shortname }}">View the project on GitHub</a>
 <img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" height="25" style="border:0px"></div>
 
 ## About


### PR DESCRIPTION
The header link is in the HTML part of the file, so the Markdown syntax is not compiled.

E.g. compare the two following GitHub pages:
- generic-environments ([page](http://coq-community.org/generic-environments/)) ([markdown](https://raw.githubusercontent.com/coq-community/generic-environments/master/index.md)) which is generated from this template, and
- lttt ([page](https://aerabi.github.io/lttt/)) ([markdown](https://raw.githubusercontent.com/aerabi/lttt/master/index.md)) which was generated from the template, and then [fixed the same way](https://github.com/aerabi/lttt/commit/c66cb57c652dada546077e6adda71b5320c5cbd8).