### PR TITLE
change name of project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#  Coq-community Templates
+# Templates for Coq projects in coq-community and elsewhere
 
 [![Contributing][contributing-shield]][contributing-link]
 [![Code of Conduct][conduct-shield]][conduct-link]


### PR DESCRIPTION
To bikeshed about names is always a perilous activity, but I think we have to do something about "Coq-community Templates", since it's too specific and not descriptive enough. 

How about: "Coq Project Templates"?