### PR TITLE
Fix generate.sh to look for values of coqdoc and dune.

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -39,6 +39,33 @@ for f in "$srcdir"/{,.}*.mustache; do
                 continue
             fi
             ;;
+        dune-project)
+            mustache='{{ dune }}'
+            bool=$(get_yaml meta.yml <<<"$mustache")
+            if [ -n "$bool" ] && [ "$bool" != false ]; then
+                : noop
+            else
+                continue
+            fi
+            ;;
+        dune)
+            mustache='{{ dune }}'
+            bool=$(get_yaml meta.yml <<<"$mustache")
+            if [ -n "$bool" ] && [ "$bool" != false ]; then
+                mkdir -p -v theories && target="theories/$target"
+            else
+                continue
+            fi
+            ;;
+        index.md)
+            mustache='{{ coqdoc }}'
+            bool=$(get_yaml meta.yml <<<"$mustache")
+            if [ -n "$bool" ] && [ "$bool" != false ]; then
+                mkdir -p -v resources && target="resources/$target"
+            else
+                continue
+            fi
+            ;;
         docker-action.yml)
             mustache='{{ action }}'
             bool=$(get_yaml meta.yml <<<"$mustache")


### PR DESCRIPTION
Do not generate the corresponding files if they were not asked for.
Put them in the right directory.

The fact that our recommended tool (`generate.sh`) has been generating unconditionally the `dune-project`, `dune` and `index.md` files without moving them to the appropriate directory has been a source of confusion for a long time (especially for `index.md`).