### PR TITLE
feat: Add index_documentation

### DIFF
--- a/index.md.mustache
+++ b/index.md.mustache
@@ -55,3 +55,5 @@ Related publications, if any, are listed below.
 {{# authors }}
 - {{& name }}{{# orcid }} [<img src="https://zenodo.org/static/img/orcid.svg" height="14px" alt="ORCID logo" />](https://orcid.org/{{ orcid }}){{/ orcid }}{{# initial }} (initial){{/ initial }}
 {{/ authors }}{{& after_authors }}
+
+{{& index_documentation }}

--- a/ref.yml
+++ b/ref.yml
@@ -388,6 +388,12 @@ fields:
         The part of the README that is not auto-generated.
       used:
         - README.md
+  - index_documentation:
+      required: false
+      description: >
+        The part of index.md that is not auto-generated.
+      used:
+        - index.md
   - coqdoc_index:
       required: false
       description: Position of Coqdoc main page relative to index


### PR DESCRIPTION
Motivated by https://github.com/coq-community/templates/pull/74#issuecomment-745973411.

`index.md` currently has no customizable entries. Should we reuse `documentation` in README or create a new field?