### PR TITLE
introduce 'ci_cron_schedule' for scheduled CI actions

### DIFF
--- a/docker-action.yml.mustache
+++ b/docker-action.yml.mustache
@@ -3,6 +3,10 @@
 name: Docker CI
 
 on:
+  {{# ci_cron_schedule }}
+  schedule:
+    - cron: '{{ ci_cron_schedule }}'
+  {{/ ci_cron_schedule }}
   push:
     branches:
       - {{branch}}{{^branch}}master{{/branch}}

--- a/nix-action.yml.mustache
+++ b/nix-action.yml.mustache
@@ -3,6 +3,10 @@
 name: Nix CI
 
 on:
+  {{# ci_cron_schedule }}
+  schedule:
+    - cron: '{{ ci_cron_schedule }}'
+  {{/ ci_cron_schedule }}
   push:
     branches:
       - {{branch}}{{^branch}}master{{/branch}}

--- a/ref.yml
+++ b/ref.yml
@@ -443,3 +443,19 @@ fields:
         - .travis.yml
         - docker-action.yml
         - config.yml
+  - ci_cron_schedule:
+      required: false
+      description: >
+        Schedule for regular actions-based CI runs (in cron syntax).
+        The implied time zone is UTC. There is no default value to
+        keep projects from running their CI all at the same time. See
+        https://crontab.guru/ for a cron expression generator. You can
+        use 'echo "$(shuf -i0-59 -n1) $(shuf -i1-5 -n1) * * *"' to
+        generate a daily schedule starting at a random night-time
+        minute.
+      examples:
+        - '5 4 * * *' #daily at 4:05
+        - '5 4 * * 0' #at 04:05 on Sunday
+      used:
+        - docker-action.yml
+        - nix-action.yml


### PR DESCRIPTION
This enables scheduled runs for actions-based CI via a new variable called `ci_cron_schedule`. As discussed in #77, there is no default value to keep everyone from using the same value. 

closes: #77 