### PR TITLE
[Nix Action] Deploy to Cachix even for PR from forks.

### DIFF
--- a/nix-action.yml.mustache
+++ b/nix-action.yml.mustache
@@ -11,8 +11,9 @@ on:
     branches:
       - {{branch}}{{^branch}}master{{/branch}}
   pull_request:
-    branches:
-      - '**'
+    paths:
+    - .github/workflows/**
+  pull_request_target:
 
 jobs:
   build:
@@ -26,16 +27,28 @@ jobs:
 {{/ tested_coq_nix_versions }}
       fail-fast: false
     steps:
+      - name: Determine which ref to test
+        run: |
+{{! Change delimiters to avoid the curly brackets on the following lines being parsed as mustache syntax. }}
+{{=<% %>=}}
+          if [ ${{ github.event_name }} = "push" ]; then
+            echo "tested_ref=${{ github.ref }}" >> $GITHUB_ENV
+          else
+            merge_commit=$(git ls-remote ${{ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge | cut -f1)
+            if [ -z "$merge_commit" ]; then
+              echo "tested_ref=refs/pull/${{ github.event.number }}/head" >> $GITHUB_ENV
+            else
+              echo "tested_ref=refs/pull/${{ github.event.number }}/merge" >> $GITHUB_ENV
+            fi
+          fi
       - uses: cachix/install-nix-action@v12
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
-{{# cachix }}
+<%# cachix %>
       - uses: cachix/cachix-action@v8
         with:
-          name: {{ name }}
-{{# push }}
-{{! Change delimiters to avoid the curly brackets on the following lines being parsed as mustache syntax. }}
-{{=<% %>=}}
+          name: <% name %>
+<%# push %>
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 <%/ push %>
 <%/ cachix %><%^ cachix %>      - uses: cachix/cachix-action@v8
@@ -52,9 +65,10 @@ jobs:
           name: math-comp
 <%/ cachix %>
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.tested_ref }}
 <%# submodule %>
-      - name: Checkout submodules
-        uses: textbook/git-checkout-submodule-action@2.1.1
+          submodules: recursive
 <%/ submodule %>
       - run: >
           nix-build https://coq.inria.fr/nix/toolbox --argstr job <% shortname %> --arg override '{ ${{ matrix.overrides }}; <% shortname %> = builtins.filterSource (path: _: baseNameOf path != ".git") ./.; }'


### PR DESCRIPTION
EDIT:

- To simplify, I kept only the first commit / first part for this PR. The next one can be reviewed separately later on.
- I've now updated this PR to be more similar to what is done in coq-community/coq-nix-toolbox#55.

### First part: Deploy to Cachix even for PR from forks.

#### Motivation

The goal is to avoid ever rebuilding the same thing twice in CI. When a PR is submitted from a fork, if it has to build a dependency, we don't want to waste this precious build time by discarding the build output. And if the PR is merged as is, it shouldn't be needed to rebuild anything once merged in the base branch (if it hasn't changed).

#### Solution

Use the `pull_request_target` event instead of the `pull_request` event to have access to secret environment variables in all cases. This is safe (no risk of linking the secret variables) even with untrusted code because `nix-build` builds the code in an isolated environment. The `pull_request_target` event ensures that the submitter of the pull request cannot change the GitHub workflow.

#### Note about modified workflows

When a GitHub workflow is modified, in order to test it, we do run it with the pull_request event. In this case, it is recommended submitted from a local branch (not from a fork) or to have an appropriate `CACHIX_AUTH_TOKEN` secret variable set in the fork.


### ~~Second part: Skip `action/checkout@v2` step if there are no submodules.~~ (kept for later)

~~Instead, we manually resolve the automatic merge commit of the PR head in the base branch created by GitHub and pass it to `nix-build` to test.~~

~~If there are submodules to check out, we fall back to the previous way of doing.~~

#### ~~Motivation~~

~~As can be seen in [this test workflow](https://github.com/coq-community/aac-tactics/runs/3282181404?check_suite_focus=true), we are more explicit on what we build. The main step shows `nix-build https://coq.inria.fr/nix/toolbox --argstr job aac-tactics --arg override '{ coq = "master"; aac-tactics = "coq-community:10361884b6907430a4acea45c0288cf534714330"; }'` instead of `nix-build https://coq.inria.fr/nix/toolbox --argstr job aac-tactics --arg override '{ coq = "master"; aac-tactics = builtins.filterSource (path: _: baseNameOf path != ".git") ./.; }'`. This means that we can reproduce the build locally (as long as the tested branches of the dependencies have not changed) by copy-pasting the command (we don't need to check out the correct ref before, and actually we don't even need to clone the repo first).~~