### PR TITLE
[Nix Action] Always test a specific commit and not a ref.

### DIFF
--- a/nix-action.yml.mustache
+++ b/nix-action.yml.mustache
@@ -27,40 +27,40 @@ jobs:
 {{/ tested_coq_nix_versions }}
       fail-fast: false
     steps:
-      - name: Determine which ref to test
+      - name: Determine which commit to test
         run: |
 {{! Change delimiters to avoid the curly brackets on the following lines being parsed as mustache syntax. }}
 {{=<% %>=}}
           if [[ ${{ github.event_name }} =~ "pull_request" ]]; then
             merge_commit=$(git ls-remote ${{ github.event.repository.html_url }} refs/pull/${{ github.event.number }}/merge | cut -f1)
             if [ -z "$merge_commit" ]; then
-              echo "tested_ref=refs/pull/${{ github.event.number }}/head" >> $GITHUB_ENV
+              echo "tested_commit=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
             else
-              echo "tested_ref=refs/pull/${{ github.event.number }}/merge" >> $GITHUB_ENV
+              echo "tested_commit=$merge_commit" >> $GITHUB_ENV
             fi
           else
-            echo "tested_ref=${{ github.ref }}" >> $GITHUB_ENV
+            echo "tested_commit=${{ github.sha }}" >> $GITHUB_ENV
           fi
-      - uses: cachix/install-nix-action@v12
+      - uses: cachix/install-nix-action@v14
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
 <%# cachix %>
-      - uses: cachix/cachix-action@v8
+      - uses: cachix/cachix-action@v10
         with:
           name: <% name %>
 <%# push %>
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 <%/ push %>
-<%/ cachix %><%^ cachix %>      - uses: cachix/cachix-action@v8
+<%/ cachix %><%^ cachix %>      - uses: cachix/cachix-action@v10
         with:
           name: coq
-      - uses: cachix/cachix-action@v8
+      - uses: cachix/cachix-action@v10
         with:
           name: coq-community
 <%# community %>
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 <%/ community %>
-      - uses: cachix/cachix-action@v8
+      - uses: cachix/cachix-action@v10
         with:
           name: math-comp
 <%/ cachix %>


### PR DESCRIPTION
This is a port of the change done in coq-community/coq-nix-toolbox#68 to avoid problems such as not testing the expected commit when re-triggering a workflow on a branch that has received new commits.

We have discovered this issue while investigating https://github.com/coq-community/hydra-battles/issues/100.

@palmskog You have the best overview of the projects that currently use this Nix CI template I think. This fix is not critical in the sense that the only issue is that retrying an old workflow will not provide reliable information.

I will open a PR to update the workflow on one project, just to make sure that I haven't made any mistake while updating the template.