### PR TITLE
[Nix Action] Use new extraPullNames option when we can.

### DIFF
--- a/nix-action.yml.mustache
+++ b/nix-action.yml.mustache
@@ -53,16 +53,11 @@ jobs:
 <%/ push %>
 <%/ cachix %><%^ cachix %>      - uses: cachix/cachix-action@v10
         with:
-          name: coq
-      - uses: cachix/cachix-action@v10
-        with:
           name: coq-community
 <%# community %>
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 <%/ community %>
-      - uses: cachix/cachix-action@v10
-        with:
-          name: math-comp
+          extraPullNames: coq, math-comp
 <%/ cachix %>
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Follow-up of coq-community/coq-nix-toolbox#71 and coq-community/coq-nix-toolbox#72.

Not critical at all, but could speed things a little.

Note that we don't use this new option when an explicit list of Cachix names is provided in `meta.yml` because there is no way to map from the current representation in `meta.yml` to one where we separate the Cachix cache we push to from the extra caches without doing computations (which mustache doesn't support).