### PR TITLE
Fix and update Nix CI

### DIFF
--- a/nix-action.yml.mustache
+++ b/nix-action.yml.mustache
@@ -61,7 +61,7 @@ jobs:
 <%/ cachix %>
       - uses: actions/checkout@v2
         with:
-          ref: ${{ env.tested_ref }}
+          ref: ${{ env.tested_commit }}
 <%# submodule %>
           submodules: recursive
 <%/ submodule %>

--- a/nix-action.yml.mustache
+++ b/nix-action.yml.mustache
@@ -41,7 +41,7 @@ jobs:
           else
             echo "tested_commit=${{ github.sha }}" >> $GITHUB_ENV
           fi
-      - uses: cachix/install-nix-action@v14
+      - uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
 <%# cachix %>


### PR DESCRIPTION
I just realized by analyzing a strange success in an aac-tactics overlay that Nix CI was completely broken for PRs since #107 because I stupidly forgot to update the `actions/checkout@v2` step.

The second commit is a port of coq-community/coq-nix-toolbox#81. I'm taking advantage that there will need to be an update of projects relying on Nix CI to do this change in passing.

I've tested that this works on the above-mentioned aac-tactics overlay.

@palmskog I can take care of updating the 9 coq-community projects using the `nix-action` tag. If you know of some other projects (e.g., external to coq-community) that also use this template, please make sure they are updated as well.