### PR TITLE
Fix submodule fetching for Docker-Coq-Action template.

### DIFF
--- a/docker-action.yml.mustache
+++ b/docker-action.yml.mustache
@@ -28,8 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 {{# submodule }}
-      - name: Checkout submodules
-        uses: textbook/git-checkout-submodule-action@2.1.1
+        with:
+          submodules: recursive
 {{/ submodule }}
       - uses: coq-community/docker-coq-action@v1
         with:


### PR DESCRIPTION
The `textbook/git-checkout-submodule-action` action had been deprecated for a while and has now stopped working (from the breakage observed in the VST repository). This fix corresponds to the one made in https://github.com/PrincetonUniversity/VST/pull/535 (which seems to have succeeding in fixing the issue) and to a previous similar change that I had done in the Nix CI template. The fact that we didn't detect it on the Coq-community side is just because AFAICT the few Coq-community projects that fetch submodules are all on Circle CI rather than GitHub Actions.