### PR TITLE
warn about opam mustache in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ YAML-compatible mustache implementation such as `ruby-mustache`
 [Debian](https://packages.debian.org/ruby-mustache) package)
 or `mustache-go` (available as a
 [Nix](https://nixos.org/nixos/packages.html?attr=mustache-go&channel=nixpkgs-unstable) package).
+Note that the `mustache` available via opam does *not* work!
 
 ### The `meta.yml` file
 


### PR DESCRIPTION
As reported by Laurent Théry on the Zulip, the `mustache` obtained via `opam install mustache` does not work, so we warn against it in the README.