### PR TITLE
add orcid as author attribute, use README.md and index.md templates

### DIFF
--- a/README.md.mustache
+++ b/README.md.mustache
@@ -80,7 +80,7 @@ Follow the instructions on https://github.com/coq-community/templates to regener
 
 - Author(s):
 {{# authors }}
-  - {{& name }}{{# initial }} (initial){{/ initial }}
+  - {{& name }}{{# orcid }} [<img src="https://zenodo.org/static/img/orcid.svg" height="14px" alt="ORCID logo" />](https://orcid.org/{{ orcid }}){{/ orcid }}{{# initial }} (initial){{/ initial }}
 {{/ authors }}
 {{& after_authors }}{{# community }}- Coq-community maintainer(s):
 {{# maintainers }}

--- a/index.md.mustache
+++ b/index.md.mustache
@@ -53,5 +53,5 @@ Related publications, if any, are listed below.
 ## Authors and contributors
 
 {{# authors }}
-- {{& name }}
+- {{& name }}{{# orcid }} [<img src="https://zenodo.org/static/img/orcid.svg" height="14px" alt="ORCID logo" />](https://orcid.org/{{ orcid }}){{/ orcid }}{{# initial }} (initial){{/ initial }}
 {{/ authors }}{{& after_authors }}

--- a/ref.yml
+++ b/ref.yml
@@ -164,6 +164,11 @@ fields:
             used:
               - coq.opam
               - extracted.opam
+        - orcid:
+            required: false
+            used:
+              - README.md
+              - index.md
   - after_authors:
       required: false
       used:


### PR DESCRIPTION
ORCIDs are a good way to track authors independently of their (possibly ambiguous) name. I implement the ORCID display in `README.md` and `index.md` following the [brand guidelines](https://info.orcid.org/brand-guidelines/).