### PR TITLE
use checkout@v3 to avoid Actions deprecations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ jobs:
   lintAllTheThings:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v1
         with:

--- a/docker-action.yml.mustache
+++ b/docker-action.yml.mustache
@@ -26,7 +26,7 @@ jobs:
 {{/ tested_coq_opam_versions }}
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 {{# submodule }}
         with:
           submodules: recursive

--- a/nix-action.yml.mustache
+++ b/nix-action.yml.mustache
@@ -59,7 +59,7 @@ jobs:
 <%/ community %>
           extraPullNames: coq, math-comp
 <%/ cachix %>
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ env.tested_commit }}
 <%# submodule %>


### PR DESCRIPTION
This should be all we need, right @Zimmi48? More context [here](https://coq.zulipchat.com/#narrow/stream/237663-coq-community-devs-.26-users/topic/Deprecations.20for.20Docker-Coq-Action/near/309567584).

cc: @erikmd 