### PR TITLE
Update cachix actions in Nix CI.

### DIFF
--- a/nix-action.yml.mustache
+++ b/nix-action.yml.mustache
@@ -41,17 +41,17 @@ jobs:
           else
             echo "tested_commit=${{ github.sha }}" >> $GITHUB_ENV
           fi
-      - uses: cachix/install-nix-action@v16
+      - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
 <%# cachix %>
-      - uses: cachix/cachix-action@v10
+      - uses: cachix/cachix-action@v12
         with:
           name: <% name %>
 <%# push %>
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 <%/ push %>
-<%/ cachix %><%^ cachix %>      - uses: cachix/cachix-action@v10
+<%/ cachix %><%^ cachix %>      - uses: cachix/cachix-action@v12
         with:
           name: coq-community
 <%# community %>


### PR DESCRIPTION
This does the same changes as https://github.com/coq-community/coq-nix-toolbox/pull/135. Since it was needed for Nix CI using the Coq Nix Toolbox directly, it is likely that this is also needed for users through the templates.