### PR TITLE
Fix links to Coq Nix Toolbox.

### DIFF
--- a/.travis.yml.mustache
+++ b/.travis.yml.mustache
@@ -62,7 +62,7 @@ language: shell
   - cachix use math-comp
 {{/ cachix }}
   script: >
-    nix-build https://coq.inria.fr/nix/toolbox --argstr job {{ shortname }} --arg override "{ $VERSIONS; {{ shortname }} = builtins.filterSource (path: _: baseNameOf path != \".git\") ./.; }"
+    nix-build https://github.com/coq-community/coq-nix-toolbox/archive/master.tar.gz --argstr job {{ shortname }} --arg override "{ $VERSIONS; {{ shortname }} = builtins.filterSource (path: _: baseNameOf path != \".git\") ./.; }"
 {{/ nix }}
 jobs:
   include:

--- a/nix-action.yml.mustache
+++ b/nix-action.yml.mustache
@@ -66,4 +66,4 @@ jobs:
           submodules: recursive
 <%/ submodule %>
       - run: >
-          nix-build https://coq.inria.fr/nix/toolbox --argstr job <% shortname %> --arg override '{ ${{ matrix.overrides }}; <% shortname %> = builtins.filterSource (path: _: baseNameOf path != ".git") ./.; }'
+          nix-build https://github.com/coq-community/coq-nix-toolbox/archive/master.tar.gz --argstr job <% shortname %> --arg override '{ ${{ matrix.overrides }}; <% shortname %> = builtins.filterSource (path: _: baseNameOf path != ".git") ./.; }'


### PR DESCRIPTION
Now that HTTP redirects do not work anymore on coq.inria.fr.

cc @palmskog 

We will need to update the projects that rely (or relied) on this template (see https://github.com/topics/nix-action):

- [ ] aac-tactics
- [ ] almost-full
- [ ] buchberger
- [ ] chapar
- [ ] jmlcoq
- [ ] pocklington
- [ ] qarith-stern-brocot
- [ ] stalmarck
- [ ] sudoku

And beyond Coq-community, in the projects:

- [ ] https://github.com/kyoDralliam/SPropTools
- [ ] https://github.com/cdepillabout/coq-equivalence-not-congruence
- [ ] https://github.com/cdepillabout/coq-playground