### PR TITLE
Docker Action: checkout v4

### DIFF
--- a/docker-action.yml.mustache
+++ b/docker-action.yml.mustache
@@ -26,7 +26,7 @@ jobs:
 {{/ tested_coq_opam_versions }}
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 {{# submodule }}
         with:
           submodules: recursive


### PR DESCRIPTION
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.