### PR TITLE
index.md: replace Octocat URL

### DIFF
--- a/index.md.mustache
+++ b/index.md.mustache
@@ -12,9 +12,9 @@ header-includes:
     <style type="text/css"> body { width: 1100px; margin-left: 30px; }</style>
 ---
 
-<div style="text-align:left"><img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" height="25" style="border:0px">
+<div style="text-align:left"><img src="https://gist.github.com/johan/1007813/raw/a25829510f049194b6404a8f98d22978e8744a6f/octocat.svg" height="25" style="border:0px">
 <a href="https://github.com/{{ organization }}/{{ shortname }}">View the project on GitHub</a>
-<img src="https://github.githubassets.com/images/modules/logos_page/Octocat.png" height="25" style="border:0px"></div>
+<img src="https://gist.github.com/johan/1007813/raw/a25829510f049194b6404a8f98d22978e8744a6f/octocat.svg" height="25" style="border:0px"></div>
 
 ## About
 


### PR DESCRIPTION
The current link yields 404 Not Found.

The proposed link comes from an unofficial Gist: https://gist.github.com/johan/1007813 .

Tested in https://coq-community.org/coq-ext-lib/