### PR TITLE
fix(nix): Add missing quotes for dev_version if custom value

### DIFF
--- a/nix-action.yml.mustache
+++ b/nix-action.yml.mustache
@@ -22,7 +22,7 @@ jobs:
       matrix:
         overrides:
 {{# tested_coq_nix_versions }}
-          - 'coq = "{{ coq_version }}"{{# extra_dev_dependencies }}; {{ nix_name }} = {{ dev_version }}{{^ dev_version }}"master"{{/ dev_version }}{{/ extra_dev_dependencies }}'
+          - 'coq = "{{ coq_version }}"{{# extra_dev_dependencies }}; {{ nix_name }} = "{{ dev_version }}{{^ dev_version }}master{{/ dev_version }}"{{/ extra_dev_dependencies }}'
 {{/ tested_coq_nix_versions }}{{^ tested_coq_nix_versions }}          - 'coq = "master"'
 {{/ tested_coq_nix_versions }}
       fail-fast: false


### PR DESCRIPTION
Hi, I believe I spotted a bug:

with the `meta.yml` snippet
```yml
tested_coq_nix_versions:
  - coq_version: 'v8.19'
    extra_dev_dependencies:
      - nix_name: mathcomp
        dev_version: 'mathcomp-2.2.0'
```
I was getting
```
      matrix:
        overrides:
          - 'coq = "v8.19"; mathcomp = mathcomp-2.2.0'
```
instead of
```
      matrix:
        overrides:
          - 'coq = "v8.19"; mathcomp = "mathcomp-2.2.0"'
```

Cc @Zimmi48 Does my patch look good to you?